### PR TITLE
Implement "wait" functionality to send/receive

### DIFF
--- a/mailbox_test.go
+++ b/mailbox_test.go
@@ -45,6 +45,29 @@ func TestMailbox(t *testing.T) {
 	}
 }
 
+func TestMailboxNoWait(t *testing.T) {
+	mb := New(3)
+	if mb.Send(1, false) != StateOK {
+		t.Fatal("Invalid state code returned")
+		return
+	}
+
+	if mb.Send(1, false) != StateOK {
+		t.Fatal("Invalid state code returned")
+		return
+	}
+
+	if mb.Send(1, false) != StateOK {
+		t.Fatal("Invalid state code returned")
+		return
+	}
+
+	if mb.Send(1, false) != StateFull {
+		t.Fatal("Invalid state code returned")
+		return
+	}
+}
+
 func BenchmarkMailbox(b *testing.B) {
 	var rwg sync.WaitGroup
 	mb := New(testBufSize)

--- a/mailbox_test.go
+++ b/mailbox_test.go
@@ -33,7 +33,7 @@ func TestMailbox(t *testing.T) {
 
 	go func() {
 		for _, si := range testSet {
-			mb.Send(si)
+			mb.Send(si, true)
 		}
 		mb.Close()
 		wg.Done()
@@ -61,7 +61,7 @@ func BenchmarkMailbox(b *testing.B) {
 	b.RunParallel(func(pb *testing.PB) {
 		var i generic.T
 		for pb.Next() {
-			mb.Send(i)
+			mb.Send(i, true)
 		}
 	})
 

--- a/mailbox_test.go
+++ b/mailbox_test.go
@@ -66,6 +66,26 @@ func TestMailboxNoWait(t *testing.T) {
 		t.Fatal("Invalid state code returned")
 		return
 	}
+
+	if _, state := mb.Receive(false); state != StateOK {
+		t.Fatal("Invalid state code returned")
+		return
+	}
+
+	if _, state := mb.Receive(false); state != StateOK {
+		t.Fatal("Invalid state code returned")
+		return
+	}
+
+	if _, state := mb.Receive(false); state != StateOK {
+		t.Fatal("Invalid state code returned")
+		return
+	}
+
+	if _, state := mb.Receive(false); state != StateEmpty {
+		t.Fatal("Invalid state code returned")
+		return
+	}
 }
 
 func BenchmarkMailbox(b *testing.B) {


### PR DESCRIPTION
This pull request will allow senders and receivers to choose not to wait on full channels. This will allow a process to continue on without blocking if a channel is full. 

*Note: The message will be considered aborted in this scenario*

```
name            old time/op    new time/op    delta
Mailbox-4         56.9ns ± 1%    61.2ns ± 0%   ~             (p=0.100 n=3+3)
BatchMailbox-4    10.5µs ± 0%    12.5µs ± 0%   ~             (p=0.100 n=3+3)

name            old alloc/op   new alloc/op   delta
Mailbox-4         0.00B ±NaN%    0.00B ±NaN%   ~     (all samples are equal)
BatchMailbox-4    0.00B ±NaN%    0.00B ±NaN%   ~     (all samples are equal)

name            old allocs/op  new allocs/op  delta
Mailbox-4          0.00 ±NaN%     0.00 ±NaN%   ~     (all samples are equal)
BatchMailbox-4     0.00 ±NaN%     0.00 ±NaN%   ~     (all samples are equal)
```